### PR TITLE
Correct filename paths to fix ES errors

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -1,6 +1,6 @@
 galaxy "omnis"
 	pos 0 -10000
-	sprite "ui/milky way"
+	sprite "map/milky way"
 		scale 0.6
 system "Omnis"
 	"jump range" 3000
@@ -1476,15 +1476,15 @@ system "Avgi "
 	object "Koryfi  "
 		distance 1200
 		offset 150
-		sprite "ship/avgi koryfi"
+		sprite "ship/avgi koryfi/koryfi"
 	object "Melodikos  "
 		distance 1200
 		offset 165
-		sprite "ship/avgi melodikos"
+		sprite "ship/avgi melodikos/melodikos"
 	object "Modified Tachytia  "
 		distance 1200
 		offset 180
-		sprite "ship/avgi tachytia"
+		sprite "ship/avgi tachytia/tachytia"
 	object "Optikon  "
 		distance 1200
 		offset 195


### PR DESCRIPTION
<img width="1040" height="117" alt="image" src="https://github.com/user-attachments/assets/5d5f7ce9-49e6-41bc-8d7f-4dff51765cc7" />

Current Omnis causes these four errors to appear in ES. This PR corrects those paths to prevent the errors from appearing.